### PR TITLE
Rebuilt image to get newest version; other small changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ version: "3.0"
 
 services:
   unifiapibrowser:
-    image: scyto/unifibrowser
+    image: quinnbatten/unifibrowser:2.0.25
     ports:
       - 8000:8000
     environment:
       - USER=apibrowser
       - "PASSWORD=${UNIFI_PASS}"
-      - UNIFIURL=https://unifi.phillycommunitywireless.org
+      - "UNIFIURL=${UNIFI_URL}"
       - DISPLAYNAME=Philly Community Wireless
       - PORT=8443
-      - APIBROWSERUSER=pcw
-      - APIBROWSERPASS=5c0f20f857a8e783e6520c25f077bf43b46bab23e14a64eec81da5c1a4aeaed0d82f3ebd4b91daaff1f3c183d0cbebf881e811165036c3189b8c988502e64a61
+      - "APIBROWSERUSER=${APIBROWSER_USER}"
+      - "APIBROWSERPASS={APIBROWSER_PASS}"
 
       # vv== This MUST be 0 ==vv
       - NOAPIBROWSERAUTH=0


### PR DESCRIPTION
- I rebuilt the docker image (new image has the latest apibrowser version), pushed the new image to my docker hub acct, pointed this repo at that image.
- Also sort of redacted some stuff that seems like it oughtn't be public.